### PR TITLE
Rename contacts page to leads

### DIFF
--- a/data.js
+++ b/data.js
@@ -244,7 +244,7 @@ const navLinks = {
     CEO: [
         { id: 'dashboard', name: 'Dashboard', icon: ICONS.dashboard },
         { id: 'deals', name: 'Deals', icon: ICONS.deals },
-        { id: 'contacts', name: 'Contacts', icon: ICONS.contacts },
+        { id: 'leads', name: 'Leads', icon: ICONS.contacts },
         { id: 'properties', name: 'Properties', icon: ICONS.properties },
         { id: 'tasks', name: 'Tasks', icon: ICONS.tasks },
         { id: 'analytics', name: 'Analytics', icon: ICONS.analytics },
@@ -255,7 +255,7 @@ const navLinks = {
         { id: 'dashboard', name: 'Dashboard', icon: ICONS.dashboard },
         { id: 'tasks', name: 'My Tasks', icon: ICONS.tasks },
         { id: 'deals', name: 'My Deals', icon: ICONS.deals },
-        { id: 'contacts', name: 'Contacts', icon: ICONS.contacts },
+        { id: 'leads', name: 'Leads', icon: ICONS.contacts },
         { id: 'properties', name: 'Properties', icon: ICONS.properties },
         { type: 'divider' },
         { id: 'my-assistant', name: 'My Assistant', icon: ICONS.assistant }
@@ -263,7 +263,7 @@ const navLinks = {
     Admin: [
         { id: 'dashboard', name: 'Dashboard', icon: ICONS.dashboard },
         { id: 'imports', name: 'Imports', icon: ICONS.imports },
-        { id: 'contacts', name: 'Manage Contacts', icon: ICONS.contacts },
+        { id: 'leads', name: 'Manage Leads', icon: ICONS.contacts },
         { id: 'properties', name: 'Manage Properties', icon: ICONS.properties },
         { id: 'settings', name: 'Settings', icon: ICONS.settings }
     ]

--- a/debug-contacts.js
+++ b/debug-contacts.js
@@ -48,10 +48,10 @@ window.addEventListener('load', function() {
     }, 1000);
 });
 
-// Авоматическая проверка при переходе на страницу контактов
+// Автоматическая проверка при переходе на страницу лидов
 window.addEventListener('hashchange', function() {
-    if (window.location.hash === '#contacts') {
-        console.log('\n=== Переход на страницу контактов ===');
+    if (window.location.hash === '#leads') {
+        console.log('\n=== Переход на страницу лидов ===');
         setTimeout(() => {
             console.log('17. Данные после перехода:', window.contactsData ? window.contactsData.length : 'Нет данных');
             console.log('18. Элементы таблицы после перехода:', {

--- a/fix-contacts-loading.js
+++ b/fix-contacts-loading.js
@@ -16,8 +16,8 @@
     // Функция инициализации контактов
     function initializeContacts() {
         // Проверяем, что мы на странице контактов
-        if (window.location.hash === '#contacts') {
-            console.log('📋 Инициализация компонентов контактов...');
+        if (window.location.hash === '#leads') {
+            console.log('📋 Инициализация компонентов лидов...');
 
             // Ждем полной загрузки DOM
             setTimeout(() => {
@@ -50,7 +50,7 @@
 
     // Обработчик изменения хэша
     window.addEventListener('hashchange', () => {
-        if (window.location.hash === '#contacts') {
+        if (window.location.hash === '#leads') {
             setTimeout(() => {
                 initializeContactComponents();
             }, 300);

--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
                     <section id="page-imports" class="page-hidden"></section>
                     <section id="page-my-assistant" class="page-hidden"></section>
                     <section id="page-my-assistant-settings" class="page-hidden"></section>
-        <section id="page-contacts" class="page-hidden"></section>
+        <section id="page-leads" class="page-hidden"></section>
                 </div>
             </main>
         </div>
@@ -176,9 +176,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // -----------------------------------------------------------------------------
     
     const navLinks = {
-        CEO: [ { id: 'dashboard', name: 'Dashboard', icon: ICONS.dashboard }, { id: 'contacts', name: 'Contacts', icon: ICONS.contacts }, { id: 'deals', name: 'Deals', icon: ICONS.deals }, { id: 'properties', name: 'Properties', icon: ICONS.properties }, { id: 'tasks', name: 'Tasks', icon: ICONS.tasks }, { id: 'analytics', name: 'Analytics', icon: ICONS.analytics }, { id: 'settings', name: 'Settings', icon: ICONS.settings }, { type: 'divider' }, { id: 'my-assistant', name: 'My Assistant', icon: ICONS.assistant }],
-        Agent: [ { id: 'dashboard', name: 'Dashboard', icon: ICONS.dashboard }, { id: 'contacts', name: 'Contacts', icon: ICONS.contacts }, { id: 'tasks', name: 'My Tasks', icon: ICONS.tasks }, { id: 'deals', name: 'My Deals', icon: ICONS.deals }, { id: 'properties', name: 'Properties', icon: ICONS.properties }, { type: 'divider' }, { id: 'my-assistant', name: 'My Assistant', icon: ICONS.assistant }],
-        Admin: [ { id: 'dashboard', name: 'Dashboard', icon: ICONS.dashboard }, { id: 'contacts', name: 'Contacts', icon: ICONS.contacts }, { id: 'imports', name: 'Imports', icon: ICONS.imports }, { id: 'properties', name: 'Manage Properties', icon: ICONS.properties }, { id: 'settings', name: 'Settings', icon: ICONS.settings }]
+        CEO: [ { id: 'dashboard', name: 'Dashboard', icon: ICONS.dashboard }, { id: 'leads', name: 'Leads', icon: ICONS.contacts }, { id: 'deals', name: 'Deals', icon: ICONS.deals }, { id: 'properties', name: 'Properties', icon: ICONS.properties }, { id: 'tasks', name: 'Tasks', icon: ICONS.tasks }, { id: 'analytics', name: 'Analytics', icon: ICONS.analytics }, { id: 'settings', name: 'Settings', icon: ICONS.settings }, { type: 'divider' }, { id: 'my-assistant', name: 'My Assistant', icon: ICONS.assistant }],
+        Agent: [ { id: 'dashboard', name: 'Dashboard', icon: ICONS.dashboard }, { id: 'leads', name: 'Leads', icon: ICONS.contacts }, { id: 'tasks', name: 'My Tasks', icon: ICONS.tasks }, { id: 'deals', name: 'My Deals', icon: ICONS.deals }, { id: 'properties', name: 'Properties', icon: ICONS.properties }, { type: 'divider' }, { id: 'my-assistant', name: 'My Assistant', icon: ICONS.assistant }],
+        Admin: [ { id: 'dashboard', name: 'Dashboard', icon: ICONS.dashboard }, { id: 'leads', name: 'Manage Leads', icon: ICONS.contacts }, { id: 'imports', name: 'Imports', icon: ICONS.imports }, { id: 'properties', name: 'Manage Properties', icon: ICONS.properties }, { id: 'settings', name: 'Settings', icon: ICONS.settings }]
     };
 
     function renderSidebar() {
@@ -205,7 +205,7 @@ document.addEventListener('DOMContentLoaded', () => {
             targetPage.classList.remove('page-hidden');
             state.currentPage = pageId;
             
-            const renderMap = { 'dashboard': renderDashboard, 'my-assistant': renderMyAssistantPage, 'my-assistant-settings': renderMyAssistantSettingsPage, 'deals': renderDealsPage, 'deal-details': () => renderDealDetailsPage(contextId), 'contacts': renderContactsPage, 'properties': renderPropertiesPage, 'property-details': () => renderPropertyDetailsPage(contextId), 'tasks': renderTasksPage, 'analytics': renderAnalyticsPage, 'settings': renderSettingsPage, 'imports': renderImportsPage };
+            const renderMap = { 'dashboard': renderDashboard, 'my-assistant': renderMyAssistantPage, 'my-assistant-settings': renderMyAssistantSettingsPage, 'deals': renderDealsPage, 'deal-details': () => renderDealDetailsPage(contextId), 'leads': renderLeadsPage, 'properties': renderPropertiesPage, 'property-details': () => renderPropertyDetailsPage(contextId), 'tasks': renderTasksPage, 'analytics': renderAnalyticsPage, 'settings': renderSettingsPage, 'imports': renderImportsPage };
             if (renderMap[pageId]) renderMap[pageId]();
 
             const pageConfig = (navLinks[state.currentUserRole] || []).find(p => p.id === pageId);
@@ -1440,9 +1440,9 @@ function clearChatHistory() {
         }
     });
 
-    // Функция рендеринга страницы контактов
-    function renderContactsPage() {
-        const page = document.getElementById('page-contacts');
+    // Функция рендеринга страницы лидов
+    function renderLeadsPage() {
+        const page = document.getElementById('page-leads');
         page.innerHTML = `
             <div class="space-y-6">
                 <!-- Верхняя панель управления -->
@@ -1461,7 +1461,7 @@ function clearChatHistory() {
                     <div class="p-6 border-b border-gray-200">
                         <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
                             <div class="flex flex-col sm:flex-row sm:items-center gap-4">
-                                <h3 class="font-semibold text-lg text-gray-900">Контакты</h3>
+                                <h3 class="font-semibold text-lg text-gray-900">Лиды</h3>
                                 <!-- Табы фильтрации -->
                                 <div id="contacts-filter-tabs" class="flex flex-wrap gap-2">
                                 </div>
@@ -1664,14 +1664,14 @@ function clearChatHistory() {
             </div>
         `;
         
-        // Инициализация функционала страницы контактов
-        initializeContactsPage();
+        // Инициализация функционала страницы лидов
+        initializeLeadsPage();
     }
 
-    // Инициализация функционала страницы контактов
-    function initializeContactsPage() {
-        console.log('🚀 Initializing contacts page...');
-        console.log('📊 Initial contactsData check:', window.contactsData);
+    // Инициализация функционала страницы лидов
+    function initializeLeadsPage() {
+        console.log('🚀 Initializing leads page...');
+        console.log('📊 Initial leadsData check:', window.contactsData);
         
         let currentFilter = 'all';
         let currentSort = { field: null, direction: 'asc' };
@@ -2325,27 +2325,27 @@ function clearChatHistory() {
 <script src="components/contact-view-modal.js"></script>
 
 <script>
-// Инициализация компонентов контактов
+// Инициализация компонентов лидов
 document.addEventListener('DOMContentLoaded', () => {
-    // Инициализируем верхнюю панель контактов при загрузке страницы контактов
-    if (window.location.hash === '#contacts' || window.location.hash === '') {
-        initializeContactsComponents();
+    // Инициализируем верхнюю панель лидов при загрузке страницы лидов
+    if (window.location.hash === '#leads' || window.location.hash === '') {
+        initializeLeadsComponents();
     }
-    
-    // Инициализируем при переходе на страницу контактов
+
+    // Инициализируем при переходе на страницу лидов
     window.addEventListener('hashchange', () => {
-        if (window.location.hash === '#contacts') {
+        if (window.location.hash === '#leads') {
             setTimeout(() => {
-                initializeContactsComponents();
+                initializeLeadsComponents();
             }, 100);
         }
     });
 });
 
-function initializeContactsComponents() {
-    // Проверяем, что мы на странице контактов и компоненты загружены
+function initializeLeadsComponents() {
+    // Проверяем, что мы на странице лидов и компоненты загружены
     if (document.getElementById('contacts-header-panel') && window.ContactsHeaderPanel) {
-        // Инициализируем верхнюю панель контактов
+        // Инициализируем верхнюю панель лидов
         window.contactsHeaderPanel = new ContactsHeaderPanel();
     }
     

--- a/public/data.js
+++ b/public/data.js
@@ -244,7 +244,7 @@ const navLinks = {
     CEO: [
         { id: 'dashboard', name: 'Dashboard', icon: ICONS.dashboard },
         { id: 'deals', name: 'Deals', icon: ICONS.deals },
-        { id: 'contacts', name: 'Contacts', icon: ICONS.contacts },
+        { id: 'leads', name: 'Leads', icon: ICONS.contacts },
         { id: 'properties', name: 'Properties', icon: ICONS.properties },
         { id: 'tasks', name: 'Tasks', icon: ICONS.tasks },
         { id: 'analytics', name: 'Analytics', icon: ICONS.analytics },
@@ -255,7 +255,7 @@ const navLinks = {
         { id: 'dashboard', name: 'Dashboard', icon: ICONS.dashboard },
         { id: 'tasks', name: 'My Tasks', icon: ICONS.tasks },
         { id: 'deals', name: 'My Deals', icon: ICONS.deals },
-        { id: 'contacts', name: 'Contacts', icon: ICONS.contacts },
+        { id: 'leads', name: 'Leads', icon: ICONS.contacts },
         { id: 'properties', name: 'Properties', icon: ICONS.properties },
         { type: 'divider' },
         { id: 'my-assistant', name: 'My Assistant', icon: ICONS.assistant }
@@ -263,7 +263,7 @@ const navLinks = {
     Admin: [
         { id: 'dashboard', name: 'Dashboard', icon: ICONS.dashboard },
         { id: 'imports', name: 'Imports', icon: ICONS.imports },
-        { id: 'contacts', name: 'Manage Contacts', icon: ICONS.contacts },
+        { id: 'leads', name: 'Manage Leads', icon: ICONS.contacts },
         { id: 'properties', name: 'Manage Properties', icon: ICONS.properties },
         { id: 'settings', name: 'Settings', icon: ICONS.settings }
     ]

--- a/public/debug-contacts.js
+++ b/public/debug-contacts.js
@@ -48,10 +48,10 @@ window.addEventListener('load', function() {
     }, 1000);
 });
 
-// Авоматическая проверка при переходе на страницу контактов
+// Автоматическая проверка при переходе на страницу лидов
 window.addEventListener('hashchange', function() {
-    if (window.location.hash === '#contacts') {
-        console.log('\n=== Переход на страницу контактов ===');
+    if (window.location.hash === '#leads') {
+        console.log('\n=== Переход на страницу лидов ===');
         setTimeout(() => {
             console.log('17. Данные после перехода:', window.contactsData ? window.contactsData.length : 'Нет данных');
             console.log('18. Элементы таблицы после перехода:', {

--- a/public/fix-contacts-loading.js
+++ b/public/fix-contacts-loading.js
@@ -16,8 +16,8 @@
     // Функция инициализации контактов
     function initializeContacts() {
         // Проверяем, что мы на странице контактов
-        if (window.location.hash === '#contacts') {
-            console.log('📋 Инициализация компонентов контактов...');
+        if (window.location.hash === '#leads') {
+            console.log('📋 Инициализация компонентов лидов...');
 
             // Ждем полной загрузки DOM
             setTimeout(() => {
@@ -50,7 +50,7 @@
 
     // Обработчик изменения хэша
     window.addEventListener('hashchange', () => {
-        if (window.location.hash === '#contacts') {
+        if (window.location.hash === '#leads') {
             setTimeout(() => {
                 initializeContactComponents();
             }, 300);

--- a/public/index.html
+++ b/public/index.html
@@ -98,7 +98,7 @@
                     <section id="page-imports" class="page-hidden"></section>
                     <section id="page-my-assistant" class="page-hidden"></section>
                     <section id="page-my-assistant-settings" class="page-hidden"></section>
-        <section id="page-contacts" class="page-hidden"></section>
+        <section id="page-leads" class="page-hidden"></section>
                 </div>
             </main>
         </div>
@@ -176,9 +176,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // -----------------------------------------------------------------------------
     
     const navLinks = {
-        CEO: [ { id: 'dashboard', name: 'Dashboard', icon: ICONS.dashboard }, { id: 'contacts', name: 'Contacts', icon: ICONS.contacts }, { id: 'deals', name: 'Deals', icon: ICONS.deals }, { id: 'properties', name: 'Properties', icon: ICONS.properties }, { id: 'tasks', name: 'Tasks', icon: ICONS.tasks }, { id: 'analytics', name: 'Analytics', icon: ICONS.analytics }, { id: 'settings', name: 'Settings', icon: ICONS.settings }, { type: 'divider' }, { id: 'my-assistant', name: 'My Assistant', icon: ICONS.assistant }],
-        Agent: [ { id: 'dashboard', name: 'Dashboard', icon: ICONS.dashboard }, { id: 'contacts', name: 'Contacts', icon: ICONS.contacts }, { id: 'tasks', name: 'My Tasks', icon: ICONS.tasks }, { id: 'deals', name: 'My Deals', icon: ICONS.deals }, { id: 'properties', name: 'Properties', icon: ICONS.properties }, { type: 'divider' }, { id: 'my-assistant', name: 'My Assistant', icon: ICONS.assistant }],
-        Admin: [ { id: 'dashboard', name: 'Dashboard', icon: ICONS.dashboard }, { id: 'contacts', name: 'Contacts', icon: ICONS.contacts }, { id: 'imports', name: 'Imports', icon: ICONS.imports }, { id: 'properties', name: 'Manage Properties', icon: ICONS.properties }, { id: 'settings', name: 'Settings', icon: ICONS.settings }]
+        CEO: [ { id: 'dashboard', name: 'Dashboard', icon: ICONS.dashboard }, { id: 'leads', name: 'Leads', icon: ICONS.contacts }, { id: 'deals', name: 'Deals', icon: ICONS.deals }, { id: 'properties', name: 'Properties', icon: ICONS.properties }, { id: 'tasks', name: 'Tasks', icon: ICONS.tasks }, { id: 'analytics', name: 'Analytics', icon: ICONS.analytics }, { id: 'settings', name: 'Settings', icon: ICONS.settings }, { type: 'divider' }, { id: 'my-assistant', name: 'My Assistant', icon: ICONS.assistant }],
+        Agent: [ { id: 'dashboard', name: 'Dashboard', icon: ICONS.dashboard }, { id: 'leads', name: 'Leads', icon: ICONS.contacts }, { id: 'tasks', name: 'My Tasks', icon: ICONS.tasks }, { id: 'deals', name: 'My Deals', icon: ICONS.deals }, { id: 'properties', name: 'Properties', icon: ICONS.properties }, { type: 'divider' }, { id: 'my-assistant', name: 'My Assistant', icon: ICONS.assistant }],
+        Admin: [ { id: 'dashboard', name: 'Dashboard', icon: ICONS.dashboard }, { id: 'leads', name: 'Manage Leads', icon: ICONS.contacts }, { id: 'imports', name: 'Imports', icon: ICONS.imports }, { id: 'properties', name: 'Manage Properties', icon: ICONS.properties }, { id: 'settings', name: 'Settings', icon: ICONS.settings }]
     };
 
     function renderSidebar() {
@@ -205,7 +205,7 @@ document.addEventListener('DOMContentLoaded', () => {
             targetPage.classList.remove('page-hidden');
             state.currentPage = pageId;
             
-            const renderMap = { 'dashboard': renderDashboard, 'my-assistant': renderMyAssistantPage, 'my-assistant-settings': renderMyAssistantSettingsPage, 'deals': renderDealsPage, 'deal-details': () => renderDealDetailsPage(contextId), 'contacts': renderContactsPage, 'properties': renderPropertiesPage, 'property-details': () => renderPropertyDetailsPage(contextId), 'tasks': renderTasksPage, 'analytics': renderAnalyticsPage, 'settings': renderSettingsPage, 'imports': renderImportsPage };
+            const renderMap = { 'dashboard': renderDashboard, 'my-assistant': renderMyAssistantPage, 'my-assistant-settings': renderMyAssistantSettingsPage, 'deals': renderDealsPage, 'deal-details': () => renderDealDetailsPage(contextId), 'leads': renderLeadsPage, 'properties': renderPropertiesPage, 'property-details': () => renderPropertyDetailsPage(contextId), 'tasks': renderTasksPage, 'analytics': renderAnalyticsPage, 'settings': renderSettingsPage, 'imports': renderImportsPage };
             if (renderMap[pageId]) renderMap[pageId]();
 
             const pageConfig = (navLinks[state.currentUserRole] || []).find(p => p.id === pageId);
@@ -1440,9 +1440,9 @@ function clearChatHistory() {
         }
     });
 
-    // Функция рендеринга страницы контактов
-    function renderContactsPage() {
-        const page = document.getElementById('page-contacts');
+    // Функция рендеринга страницы лидов
+    function renderLeadsPage() {
+        const page = document.getElementById('page-leads');
         page.innerHTML = `
             <div class="space-y-6">
                 <!-- Верхняя панель управления -->
@@ -1461,7 +1461,7 @@ function clearChatHistory() {
                     <div class="p-6 border-b border-gray-200">
                         <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
                             <div class="flex flex-col sm:flex-row sm:items-center gap-4">
-                                <h3 class="font-semibold text-lg text-gray-900">Контакты</h3>
+                                <h3 class="font-semibold text-lg text-gray-900">Лиды</h3>
                                 <!-- Табы фильтрации -->
                                 <div id="contacts-filter-tabs" class="flex flex-wrap gap-2">
                                 </div>
@@ -1664,14 +1664,14 @@ function clearChatHistory() {
             </div>
         `;
         
-        // Инициализация функционала страницы контактов
-        initializeContactsPage();
+        // Инициализация функционала страницы лидов
+        initializeLeadsPage();
     }
 
-    // Инициализация функционала страницы контактов
-    function initializeContactsPage() {
-        console.log('🚀 Initializing contacts page...');
-        console.log('📊 Initial contactsData check:', window.contactsData);
+    // Инициализация функционала страницы лидов
+    function initializeLeadsPage() {
+        console.log('🚀 Initializing leads page...');
+        console.log('📊 Initial leadsData check:', window.contactsData);
         
         let currentFilter = 'all';
         let currentSort = { field: null, direction: 'asc' };
@@ -2325,27 +2325,27 @@ function clearChatHistory() {
 <script src="components/contact-view-modal.js"></script>
 
 <script>
-// Инициализация компонентов контактов
+// Инициализация компонентов лидов
 document.addEventListener('DOMContentLoaded', () => {
-    // Инициализируем верхнюю панель контактов при загрузке страницы контактов
-    if (window.location.hash === '#contacts' || window.location.hash === '') {
-        initializeContactsComponents();
+    // Инициализируем верхнюю панель лидов при загрузке страницы лидов
+    if (window.location.hash === '#leads' || window.location.hash === '') {
+        initializeLeadsComponents();
     }
-    
-    // Инициализируем при переходе на страницу контактов
+
+    // Инициализируем при переходе на страницу лидов
     window.addEventListener('hashchange', () => {
-        if (window.location.hash === '#contacts') {
+        if (window.location.hash === '#leads') {
             setTimeout(() => {
-                initializeContactsComponents();
+                initializeLeadsComponents();
             }, 100);
         }
     });
 });
 
-function initializeContactsComponents() {
-    // Проверяем, что мы на странице контактов и компоненты загружены
+function initializeLeadsComponents() {
+    // Проверяем, что мы на странице лидов и компоненты загружены
     if (document.getElementById('contacts-header-panel') && window.ContactsHeaderPanel) {
-        // Инициализируем верхнюю панель контактов
+        // Инициализируем верхнюю панель лидов
         window.contactsHeaderPanel = new ContactsHeaderPanel();
     }
     


### PR DESCRIPTION
## Summary
- rename the Contacts navigation entry and route to Leads across the app shell and build assets
- retitle and remap the contacts page rendering logic so the Leads page content and heading load under the new `#leads` hash
- update supporting scripts that watch the location hash to expect `#leads`

## Testing
- npm run lint:check *(fails: eslint CLI no longer accepts --ext with eslint.config.js)*
- npx eslint . *(fails: existing configuration reports module parsing error and warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c92f00fedc832dbdc02d0e8557e918